### PR TITLE
Fix path error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,6 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.5)
 
-set(EXTRA_COMPONENT_DIRS /components)
+set(EXTRA_COMPONENT_DIRS ./components)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(a2dp_sink)


### PR DESCRIPTION
```
CMake Error
  Directory specified in EXTRA_COMPONENT_DIRS doesn't exist: /components
```